### PR TITLE
feat(ChartView): update marker to show only one marker when both bars…

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -491,28 +491,38 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             isDrawMarkersEnabled,
             valuesToHighlight()
             else { return }
-        
+
+        var drawYMax: CGFloat = 1000.0
+
         for highlight in highlighted
         {
-            guard
-                let set = data?[highlight.dataSetIndex],
-                let e = data?.entry(for: highlight)
-                else { continue }
-            
-            let entryIndex = set.entryIndex(entry: e)
-            guard entryIndex <= Int(Double(set.entryCount) * chartAnimator.phaseX) else { continue }
-
-            let pos = getMarkerPosition(highlight: highlight)
-
-            // check bounds
-            guard viewPortHandler.isInBounds(x: pos.x, y: pos.y) else { continue }
-
-            // callbacks to update the content
-            marker.refreshContent(entry: e, highlight: highlight)
-            
-            // draw the marker
-            marker.draw(context: context, point: pos)
+            if highlight.drawY < drawYMax {
+                drawYMax = highlight.drawY
+            }
         }
+
+        let highlightMax = highlighted.filter { bar in
+            bar.drawY == drawYMax
+        }[0]
+
+        guard
+            let set = data?[highlightMax.dataSetIndex],
+            let e = data?.entry(for: highlightMax)
+            else { return }
+
+        let entryIndex = set.entryIndex(entry: e)
+        guard entryIndex <= Int(Double(set.entryCount) * chartAnimator.phaseX) else { return }
+
+        let pos = getMarkerPosition(highlight: highlightMax)
+
+        // check bounds
+        guard viewPortHandler.isInBounds(x: pos.x, y: pos.y) else { return }
+
+        // callbacks to update the content
+        marker.refreshContent(entry: e, highlight: highlightMax)
+
+        // draw the marker
+        marker.draw(context: context, point: pos)
     }
     
     /// - Returns: The actual position in pixels of the MarkerView for the given Entry in the given DataSet.


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
2 markers are displaying when 2 bars are selected which is not according to current design

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Update Marker so when there is 2 datasets and 2 bars are selected, only the one marker will be displayed

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->