### PR TITLE
refactor: support multiple bar items only displaying 1 marker in a mo…

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -491,8 +491,36 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             isDrawMarkersEnabled,
             valuesToHighlight()
             else { return }
+
         
-        for highlight in highlighted
+        // Find unique data indexes.
+        var uniqueIndices: [Int] = []
+        
+        for highlight in highlighted {
+            if uniqueIndices.contains(highlight.dataIndex) {
+                continue
+            }
+            
+            uniqueIndices.append(highlight.dataIndex)
+        }
+        
+        // Find tallest items given each data index.
+        var filteredHighlighted: [Highlight] = []
+        for index in uniqueIndices {
+            let itemsWithSameIndex = highlighted.filter { $0.dataIndex == index }
+            
+            var drawYMax: CGFloat = 1000.0
+            var tallestItem = itemsWithSameIndex[0]
+            for item in itemsWithSameIndex {
+                if item.drawY < drawYMax {
+                    drawYMax = item.drawY
+                    tallestItem = item
+                }
+            }
+            filteredHighlighted.append(tallestItem)
+        }
+
+        for highlight in filteredHighlighted
         {
             guard
                 let set = data?[highlight.dataSetIndex],


### PR DESCRIPTION
Support multiple bar items only displaying 1 marker without changing the original behaviour too drastically.

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Only draw one marker if multiple items in the same data index is highlighted.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Filtered highlighted array in ChartViewBase.drawMarkers()

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->