### PR TITLE
fix(Highlight): fix bars being selected when tapping on empty spaces between bars

### DIFF
--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -102,6 +102,10 @@ open class ChartBaseDataSet: NSObject, ChartDataSetProtocol, NSCopying
     {
         fatalError("entriesForXValue is not implemented in ChartBaseDataSet")
     }
+
+    open func entriesForXValue(_ xValue: Double, barWidth: Double) -> [ChartDataEntry] {
+        fatalError("entriesForXValue(xValue, barWidth) is not implemented in ChartBaseDataSet")
+    }
     
     open func entryIndex(
         x xValue: Double,

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -50,6 +50,8 @@ open class ChartDataSet: ChartBaseDataSet
     {
         self.init(entries: entries, label: "DataSet")
     }
+    /// instance of the data-provider
+    @objc public weak var chart: ChartDataProvider?
 
     // MARK: - Data functions and accessors
 
@@ -198,6 +200,20 @@ open class ChartDataSet: ChartBaseDataSet
     {
         let match: (ChartDataEntry) -> Bool = {
             $0.x > xValue - 0.5 && $0.x <= xValue + 0.5
+        }
+        guard let ind = firstIndex(where: match) else {
+            return []
+        }
+        let i = distance(from: startIndex, to: ind)
+        return self[i...].prefix(while: match)
+    }
+
+    /// - Returns: All Entry objects found at the given x-value and located within specified barwidth with binary search.
+    /// An empty array if no Entry object at that x-value.
+    open override func entriesForXValue(_ xValue: Double, barWidth: Double) -> [ChartDataEntry] {
+        let match: (ChartDataEntry) -> Bool = {
+            let halfBarWidth = barWidth / 2.0
+            return $0.x > xValue - halfBarWidth && $0.x <= xValue + halfBarWidth
         }
         guard let ind = firstIndex(where: match) else {
             return []

--- a/Source/Charts/Data/Interfaces/ChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/ChartDataSetProtocol.swift
@@ -72,6 +72,10 @@ public protocol ChartDataSetProtocol
     /// - Returns: All Entry objects found at the given x-value with binary search.
     /// An empty array if no Entry object at that x-value.
     func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
+
+    /// - Returns: All Entry objects found at the given x-value and located within specified barwidth with binary search.
+    /// An empty array if no Entry object at that x-value.
+    func entriesForXValue(_ xValue: Double, barWidth: Double) -> [ChartDataEntry]
     
     /// - Parameters:
     ///   - xValue: x-value of the entry to search for

--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -48,7 +48,7 @@ open class ChartHighlighter : NSObject, Highlighter
     @objc open func getHighlight(xValue xVal: Double, x: CGFloat, y: CGFloat) -> Highlight?
     {
         guard let chart = chart else { return nil }
-        
+
         let closestValues = getHighlights(xValue: xVal, x: x, y: y)
         guard !closestValues.isEmpty else { return nil }
         
@@ -92,13 +92,20 @@ open class ChartHighlighter : NSObject, Highlighter
         rounding: ChartDataSetRounding) -> [Highlight]
     {
         guard let chart = self.chart as? BarLineScatterCandleBubbleChartDataProvider else { return [] }
-        
-        var entries = set.entriesForXValue(xValue)
-        if entries.isEmpty, let closest = set.entryForXValue(xValue, closestToY: .nan, rounding: rounding)
-        {
-            // Try to find closest x-value and take all entries for that x-value
-            entries = set.entriesForXValue(closest.x)
+
+        let barWidth = (self.chart as? BarChartDataProvider)?.barData?.barWidth
+        var entries: [ChartDataEntry] = []
+        if let barWidth = barWidth {
+            entries = set.entriesForXValue(xValue, barWidth: barWidth)
+        } else {
+            entries = set.entriesForXValue(xValue)
         }
+        // Note: removed this check to prevent bars being selected when entries array is empty
+         // if entries.isEmpty, let closest = set.entryForXValue(xValue, closestToY: .nan, rounding: rounding)
+        // {
+        //      Try to find closest x-value and take all entries for that x-value
+        //      entries = set.entriesForXValue(closest.x)
+        // }
 
         return entries.map { e in
             let px = chart.getTransformer(forAxis: set.axisDependency)


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
Bars being selected when tapping on empty spaces between bars

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Bars should only be selected when tapping within bars

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Update range accepted for bar entry values with barWidth
Remove check for empty entries array which forces bar selection

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->